### PR TITLE
Run dynamodb in memory if databaseDir is null.

### DIFF
--- a/lib/launch.js
+++ b/lib/launch.js
@@ -8,16 +8,16 @@ var cp = require('child_process')
 var path = require('path')
 
 /**
- * @param {string} databaseDir The location of database files.
+ * @param {?string} databaseDir The location of database files. Will run in memory if null.
  * @param {number} port
  * @return {ChildProcess}
  */
 function launch(databaseDir, port) {
-  var workingDir = path.resolve(databaseDir)
+  var opts = {env: process.env}
   var javaDir = path.join(__dirname, '..', 'aws_dynamodb_local')
   var libDir = path.join(javaDir, 'DynamoDBLocal_lib')
-
   var cmd = 'java'
+
   var args = [
     '-Djava.library.path=' + libDir,
     '-jar',
@@ -25,7 +25,14 @@ function launch(databaseDir, port) {
     '--port',
     port
   ]
-  return cp.spawn(cmd, args, {cwd: workingDir, env: process.env})
+
+  if (databaseDir === null) {
+    args.push('--inMemory')
+  } else {
+    opts.cwd = path.resolve(databaseDir)
+  }
+
+  return cp.spawn(cmd, args, opts)
 }
 
 module.exports = {launch: launch}


### PR DESCRIPTION
I need the ability to programmatically launch a local dynamo in memory. Supplying a `null` argument for `databaseDir` seems like it makes sense for this.