### PR TITLE
Create db directory before launch

### DIFF
--- a/lib/launch.js
+++ b/lib/launch.js
@@ -6,6 +6,7 @@
 
 var cp = require('child_process')
 var path = require('path')
+var mkdirp = require('mkdirp')
 
 /**
  * An options object:
@@ -65,6 +66,7 @@ function launch(options, port) {
 
   if (options.dir) {
     opts.cwd = path.resolve(options.dir)
+    mkdirp.sync(opts.cwd)
   } else {
     args.push('--inMemory')
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "flags": "0.1.2",
     "kew": "0.4.0",
     "metrics": "0.1.8",
+    "mkdirp": "~0.5.1",
     "progress": "1.1.8"
   },
   "devDependencies": {


### PR DESCRIPTION
For convenience, create the db directory before launching (if it doesn't exist).