### PR TITLE
Add bin reference to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "dynamodb",
     "dynamodb local"
   ],
+  "bin": {
+    "local-dynamo": "./bin/launch_local_dynamo"
+  },
   "main": "lib/launch.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This will add a symbolic in the `node_modules/.bin` folder. The executable can then be run with `local-dynamo` instead of `./node_modules/local-dynamo/bin/launch_local_dynamo` from the folder where the package has been installed.