### PR TITLE
Make the java not to force close when sharedDb is specified

### DIFF
--- a/lib/launch.js
+++ b/lib/launch.js
@@ -56,10 +56,6 @@ function launch(options, port) {
     args.push('-Xmx' + options.heap)
   }
 
-  if (options.sharedDb) {
-    args.push('-sharedDb')
-  }
-
   args.push(
       '-jar',
       path.join(javaDir, 'DynamoDBLocal.jar'),
@@ -71,6 +67,10 @@ function launch(options, port) {
     opts.cwd = path.resolve(options.dir)
   } else {
     args.push('--inMemory')
+  }
+
+  if (options.sharedDb) {
+    args.push('-sharedDb')
   }
 
   return cp.spawn(cmd, args, opts)


### PR DESCRIPTION
So, the latest release `v0.4.0` have a bug. If one specifies the `sharedDb: true` then local-dynamo cannot be started. It prints:
```
Unrecognized option: -sharedDb
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

This PR fixes it all!
We just need to move the `-sharedDb` switch to the end of the command line.

<img src="https://i.makeagif.com/media/6-17-2015/wMDHKb.gif" />