### PR TITLE
Add --sharedDb flag to launcher

### DIFF
--- a/bin/launch_local_dynamo.js
+++ b/bin/launch_local_dynamo.js
@@ -9,10 +9,12 @@ var localDynamo = require('../lib/launch.js')
 
 flags.defineString('database_dir', '', 'The location for databases files. Run in memory if omitted.')
 flags.defineNumber('port', 4567, 'A port to run DynamoDB Local')
+flags.defineBoolean('sharedDb', false, 'Use a single database file, instead of separate files for each credential and region')
 flags.parse()
 
 var childProcess = localDynamo.launch({
   dir: flags.get('database_dir') || null,
+  sharedDb: flags.get('sharedDb'),
   stdio: 'pipe'
 }, flags.get('port'))
 childProcess.stdout.pipe(process.stdout)


### PR DESCRIPTION
We would like to be able to use the standalone launcher with the `-sharedDb` flag, so I added it to your launcher script. 

Thanks!