### PR TITLE
Add shebang in bin script

### DIFF
--- a/bin/launch_local_dynamo.js
+++ b/bin/launch_local_dynamo.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // Copyright 2013 The Obvious Corporation.
 
 /**


### PR DESCRIPTION
Currently, package.json states:

```json
  "bin": {
    "local-dynamo": "./bin/launch_local_dynamo.js"
  }
```

So `npm install local-dynamo` in user's project will generates node_modules/.bin/local-dynamo file with contents of bin/launch_local_dynamo.js.

Though bin/launch_local_dynamo.js currently does not have shebang so executing it directly from shells or via `npm run` will cause syntax error.

This PR adds it so now you can do these from user's project:

```bash
$ npm install local-dynamo
$ node_modules/.bin/local-dynamo
Initializing DynamoDB Local with the following configuration:
Port:	4567
InMemory:	true
DbPath:	null
SharedDb:	false
shouldDelayTransientStatuses:	false
CorsParams:	*
```

```bash
# With npm-scripts in package.json like this
# "scripts": {
#   "dynamo": "local-dynamo"
# }
$ npm run dynamo
Initializing DynamoDB Local with the following configuration:
Port:	4567
InMemory:	true
DbPath:	null
SharedDb:	false
shouldDelayTransientStatuses:	false
CorsParams:	*
```

Also, `node` binary can handle shebang in passed script, so usage example in README.md should keep working.
```bash
$ node bin/launch_local_dynamo.js
Initializing DynamoDB Local with the following configuration:
Port:	4567
InMemory:	true
DbPath:	null
SharedDb:	false
shouldDelayTransientStatuses:	false
CorsParams:	*
```